### PR TITLE
Portability upgrade

### DIFF
--- a/DEFCON2/DC-Configurator.ps1
+++ b/DEFCON2/DC-Configurator.ps1
@@ -1,5 +1,6 @@
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON2/DC-D2C-Configurator-NoAudit.ps1
+++ b/DEFCON2/DC-D2C-Configurator-NoAudit.ps1
@@ -3,8 +3,8 @@ $wechost = "<WECSERVER>"
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
-
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)
 cd $Env:WinDir

--- a/DEFCON2/DC-D2C-Configurator.ps1
+++ b/DEFCON2/DC-D2C-Configurator.ps1
@@ -3,7 +3,8 @@ $wechost = "<WECSERVER>"
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON3/DC-Configurator.ps1
+++ b/DEFCON3/DC-Configurator.ps1
@@ -1,5 +1,6 @@
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON3/DC-D3C-Configurator-NoAudit.ps1
+++ b/DEFCON3/DC-D3C-Configurator-NoAudit.ps1
@@ -3,7 +3,8 @@ $wechost = "<WECSERVER>"
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON3/DC-D3C-Configurator.ps1
+++ b/DEFCON3/DC-D3C-Configurator.ps1
@@ -3,7 +3,8 @@ $wechost = "<WECSERVER>"
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON3/Sysmon-Configurator.ps1
+++ b/DEFCON3/Sysmon-Configurator.ps1
@@ -3,7 +3,8 @@ $sysmonshare = Read-Host("Enter Sysmon UNC path: ")
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON3/Sysmon_Updater.ps1
+++ b/DEFCON3/Sysmon_Updater.ps1
@@ -3,7 +3,8 @@ $sysmonshare = Read-Host("Enter Sysmon UNC path: ")
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON4/DC-Configurator-NoAudit.ps1
+++ b/DEFCON4/DC-Configurator-NoAudit.ps1
@@ -3,7 +3,8 @@ $wechost = "<WECSERVER>"
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON4/DC-Configurator.ps1
+++ b/DEFCON4/DC-Configurator.ps1
@@ -3,7 +3,8 @@ $wechost = "<WECSERVER>"
 
 
 # Get working directory of this script to return to
-$startdir = ($pwd).path
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
  	
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)

--- a/DEFCON4/WEC-Configurator.ps1
+++ b/DEFCON4/WEC-Configurator.ps1
@@ -10,20 +10,21 @@ cd $Env:WinDir
 mkdir \tmp-eventlogging\ > $null
 cd \tmp-eventlogging\
 
+#Copy traveling files
+cp $startdir\winlogbeat.yml \tmp-eventlogging\winlogbeat.yml
+### Dont need this cert for prod however people on Github may.
+cp $startdir\ca.crt \tmp-eventlogging\ca.crt
 
 # Download Tools
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Invoke-WebRequest -URI https://artifacts.elastic.co/downloads/beats/winlogbeat/winlogbeat-7.13.2-windows-x86_64.zip -OutFile "WinLogBeat.zip"
 Invoke-WebRequest -URI https://github.com/blackhillsinfosec/EventLogging/archive/master.zip -OutFile "EventLogging.zip"
-Invoke-WebRequest -URI "<WinLogBeatConf>" -OutFile "WEC.zip"
-Invoke-WebRequest -URI "<certurl>" -OutFile "ca.crt"
 
 
 # Expand Tools
 Expand-Archive .\WinLogBeat.zip '\Program Files\'
 Rename-Item '\Program Files\winlogbeat-7.13.2-windows-x86_64' WinLogBeat
 Expand-Archive .\EventLogging.zip
-Expand-Archive .\WEC.zip
 
 
 # Install WinLogBeat as service
@@ -33,7 +34,7 @@ powershell -Exec bypass -File .\install-service-winlogbeat.ps1 > $null
 Set-Service -name "winlogbeat" -StartupType automatic
 cp '\program files\WinLogBeat\winlogbeat.yml' '\program files\winlogbeat\winlogbeat.yml.old'
 $null > '\program files\winlogbeat\winlogbeat.yml'
-Get-Content \tmp-eventlogging\WEC\WEC\winlogbeat.yml > '\program files\winlogbeat\winlogbeat.yml'
+Get-Content \tmp-eventlogging\winlogbeat.yml > '\program files\winlogbeat\winlogbeat.yml'
 Start-Service -name "winlogbeat"
 Get-Service -name "winlogbeat"
 

--- a/DEFCON4/WEC-Configurator.ps1
+++ b/DEFCON4/WEC-Configurator.ps1
@@ -1,6 +1,6 @@
 # Get working directory of this script to return to
-$startdir = ($pwd).path
-
+$invocation = $MyInvocation.MyCommand.Path
+$startdir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)
 cd $Env:WinDir
@@ -12,7 +12,6 @@ cd \tmp-eventlogging\
 
 #Copy traveling files
 cp $startdir\winlogbeat.yml \tmp-eventlogging\winlogbeat.yml
-### Dont need this cert for prod however people on Github may.
 cp $startdir\ca.crt \tmp-eventlogging\ca.crt
 
 # Download Tools


### PR DESCRIPTION
CA and Winlogbeat config should now be placed in the same folder as the script. This allows the whole package to be packaged up into a single archive and moved as needed. Also eliminates the need to host the files on a webserver. Also replaced usage of pwd with $MyInvocation.MyCommand.Path which is more accurate and allows for execution from other locations.  