### PR TITLE
Added Defender Exceptions

### DIFF
--- a/DEFCON3/sysmon/sysmon.ps1
+++ b/DEFCON3/sysmon/sysmon.ps1
@@ -27,7 +27,7 @@ if ($checksharelog -eq $false)
 cd $Env:WinDir
 
 #Add exclusion for sysmonconfig due to false posisitve in windows Defender.
-Add-MpPreference -ExclusionPath "C:\Windows\sysmonconfig.xml"
+Add-MpPreference -ExclusionPath $localsysmonconfig
 Add-MpPreference -ExclusionPath $sysmonshareconfig
 #if file has been removed copy it back down.
 if($(test-path $localsysmonconfig) -eq $false){copy-item $sysmonshareconfig $localsysmonconfig}

--- a/DEFCON3/sysmon/sysmon.ps1
+++ b/DEFCON3/sysmon/sysmon.ps1
@@ -26,6 +26,11 @@ if ($checksharelog -eq $false)
 # Change to WinDir directory, script will perform work using this drive (Usually C:\)
 cd $Env:WinDir
 
+#Add exclusion for sysmonconfig due to false posisitve in windows Defender.
+Add-MpPreference -ExclusionPath "C:\Windows\sysmonconfig.xml"
+Add-MpPreference -ExclusionPath $sysmonshareconfig
+#if file has been removed copy it back down.
+if($(test-path $localsysmonconfig) -eq $false){copy-item $sysmonshareconfig $localsysmonconfig}
 
 Function main{
 


### PR DESCRIPTION
The Sysmon config is being flagged as Malware due to it having lines looking for tampering in the Defender engine. This is being interpreted by defender as attempts to tamper with its internal engine. 