### PR TITLE
Add failure to auditing account lockouts

### DIFF
--- a/DEFCON4/Group-Policy-Objects/SOC-DC-Enhanced-Auditing/{B53356EF-67DC-481C-A4E9-4FE2C9295F3D}/DomainSysvol/GPO/Machine/microsoft/windows nt/Audit/audit.csv
+++ b/DEFCON4/Group-Policy-Objects/SOC-DC-Enhanced-Auditing/{B53356EF-67DC-481C-A4E9-4FE2C9295F3D}/DomainSysvol/GPO/Machine/microsoft/windows nt/Audit/audit.csv
@@ -11,7 +11,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Audit Process Creation,{0cce922b-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Directory Service Access,{0cce923b-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Directory Service Changes,{0cce923c-69ae-11d9-bed3-505054503030},Success and Failure,,3
-,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success and Failure,,1
+,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Logoff,{0cce9216-69ae-11d9-bed3-505054503030},Success,,1
 ,System,Audit Logon,{0cce9215-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Other Logon/Logoff Events,{0cce921c-69ae-11d9-bed3-505054503030},Success and Failure,,3

--- a/DEFCON4/Group-Policy-Objects/SOC-DC-Enhanced-Auditing/{B53356EF-67DC-481C-A4E9-4FE2C9295F3D}/DomainSysvol/GPO/Machine/microsoft/windows nt/Audit/audit.csv
+++ b/DEFCON4/Group-Policy-Objects/SOC-DC-Enhanced-Auditing/{B53356EF-67DC-481C-A4E9-4FE2C9295F3D}/DomainSysvol/GPO/Machine/microsoft/windows nt/Audit/audit.csv
@@ -11,7 +11,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Audit Process Creation,{0cce922b-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Directory Service Access,{0cce923b-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Directory Service Changes,{0cce923c-69ae-11d9-bed3-505054503030},Success and Failure,,3
-,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success,,1
+,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success and Failure,,1
 ,System,Audit Logoff,{0cce9216-69ae-11d9-bed3-505054503030},Success,,1
 ,System,Audit Logon,{0cce9215-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Other Logon/Logoff Events,{0cce921c-69ae-11d9-bed3-505054503030},Success and Failure,,3


### PR DESCRIPTION
Updates the "Audit Account Lockout" setting to "Success and Failure" from just "Success".